### PR TITLE
Fix swapped comment capture scopes (only the # was highlighted)

### DIFF
--- a/grammars/moose.json
+++ b/grammars/moose.json
@@ -299,10 +299,10 @@
           "match": "^\\s*((#+).*)",
           "captures": {
             "1": {
-              "name": "punctuation.definition.comment.moose"
+              "name": "comment.line.number-sign.moose"
             },
             "2": {
-              "name": "comment.line.number-sign.moose"
+              "name": "punctuation.definition.comment.moose"
             }
           }
         },
@@ -310,10 +310,10 @@
           "match": "((#+).*)",
           "captures": {
             "1": {
-              "name": "punctuation.definition.comment.moose"
+              "name": "comment.line.number-sign.moose"
             },
             "2": {
-              "name": "comment.line.number-sign.moose"
+              "name": "punctuation.definition.comment.moose"
             }
           }
         }


### PR DESCRIPTION
Addresses the comment highlighting reported in https://github.com/idaholab/moose-language-support/discussions/33.

Both patterns in `repository.comments` (`grammars/moose.json`) assigned their capture-group scopes in reverse: the whole comment matched `punctuation.definition.comment.moose` and only the leading `#` matched `comment.line.number-sign.moose`. On themes that style `comment.*` but not `punctuation.definition.comment` (e.g. VS Code's Dark Modern), this left the comment body uncolored and highlighted only the `#`. Themes that color `punctuation.definition.comment` (e.g. Atom One Dark) masked it, which is why it went unnoticed.

This swaps the two so the whole match is `comment.line.number-sign.moose` and the `#` marker is `punctuation.definition.comment.moose`.

Verified by tokenizing a sample comment with `vscode-textmate` + the Dark Modern theme (the comment body now resolves to the comment color instead of the default foreground) and by a live editor check on Dark Modern.